### PR TITLE
Required SEAS Penn email re Google OAuth, Supabase local env vars support

### DIFF
--- a/LOCAL_SUPABASE_SETUP.md
+++ b/LOCAL_SUPABASE_SETUP.md
@@ -47,20 +47,20 @@ This configuration allows you to use Google OAuth locally with Supabase's built-
 
 ## .env Local File Setup
 
-Here is an example of what your `.env` file should contain for local development:
+Here is an example of what your `.env` file should contain for local development. 
 
 ```plaintext
-NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from the local Supabase start console log>
+NEXT_PUBLIC_SUPABASE_LOCAL_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_LOCAL_ANON_KEY=<anon key from the local Supabase start console log>
 ON_DEMAND_ISR_TOKEN=<whatever secret you want to come up with>
 POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 GOOGLE_CLIENT_ID=<from Google Cloud settings>
 GOOGLE_CLIENT_SECRET=<from Google Cloud settings>
 ```
 
-In case the above `NEXT_PUBLIC_SUPABASE_URL` does not work, try instead:
+In case the above `NEXT_PUBLIC_SUPABASE_LOCAL_URL` does not work, try instead:
 ```plaintext
-NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_LOCAL_URL=http://localhost:54321
 ```
 
 This setup ensures your local environment is correctly configured to work with Supabase and Google OAuth authentication. For more information on setting your On-Demand ISR token, see the [ISR Vercel Documentation](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration).

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,17 +10,10 @@ import {
   useMediaQuery,
   useTheme,
   Hidden,
-  Alert,
   Snackbar,
-  SnackbarCloseReason,
 } from "@mui/material";
-import {
-  AccountCircle,
-  Brightness3,
-  Brightness4,
-  Brightness7,
-} from "@mui/icons-material";
-import { User, AuthSession, Session } from "@supabase/supabase-js";
+import { AccountCircle, Brightness3, Brightness7 } from "@mui/icons-material";
+import { User, Session } from "@supabase/supabase-js";
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
@@ -84,7 +77,7 @@ function UserComponent({
     return () => {
       authListener.subscription.unsubscribe();
     };
-  }, []);
+  }, [router, setEmailError]);
 
   if (user) {
     return (

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,19 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+// check if env is prod or dev
+const isProduction = process.env.NODE_ENV === "production";
+
+// sync the supabase env vars for whether in prod or dev
+const supabaseUrl = isProduction
+  ? process.env.NEXT_PUBLIC_SUPABASE_URL!
+  : process.env.NEXT_PUBLIC_SUPABASE_LOCAL_URL!;
+
+console.log(supabaseUrl);
+
+const supabaseAnonKey = isProduction
+  ? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  : process.env.NEXT_PUBLIC_SUPABASE_LOCAL_ANON_KEY!;
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export const authSupabase = (authHeader: string) => {


### PR DESCRIPTION
Several changes:

- Google OAuth attempted logins without @seas.upenn.edu email domains will get immediately logged out and routed to '/', and a Vercel analytics event will be captured to track how often this happens (can view in the Vercel analytics dashboard).
- A MUI Snackbar toast will appear to the user informing them they need to login with a SEAS email if the above happens.
- Changed `supabase.ts` to automatically toggle between local db env vars and prod db env vars depending on production environment. **NOTE: very important that for local dev you add the following env vars and populate them with your local supabase env values: `NEXT_PUBLIC_SUPABASE_LOCAL_URL` and `NEXT_PUBLIC_SUPABASE_LOCAL_ANON_KEY`**
- Changes made to the Local Supabase Markdown doc to reflect these different env vars.