### PR TITLE
Implemented Google OAuth level scoping to seas.upenn.edu emails

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -160,6 +160,9 @@ function UserComponent({
           .signInWithOAuth({
             provider: "google",
             options: {
+              queryParams: {
+                hd: "seas.upenn.edu", // only allow UPenn SEAS emails
+              },
               redirectTo: `${baseUrl}`, // redirect to route after OAuth complete
             },
           })


### PR DESCRIPTION
I was reading these docs (https://developers.google.com/identity/openid-connect/openid-connect#hd-param) @krisstern and found an even more robust solution -- Google OAuth supports gating by domain at the Google OAuth level itself.

I think the client-side check may be OK to keep in there as an extra security layer, but now I think it's really robust (client-side checks are less robust anyway, so it's good that Google supports this, as I could find nothing in the Supabase docs itself).

All that needed to be changed was added `queryParams` and `hd`:

```
        supabase.auth
          .signInWithOAuth({
            provider: "google",
            options: {
              queryParams: {
                hd: "seas.upenn.edu", // only allow UPenn SEAS emails
              },
              redirectTo: `${baseUrl}`, // redirect to route after OAuth complete
            },
          })
```

And this elegant result happens:
<img width="1030" alt="Screenshot 2024-03-17 at 9 33 59 PM" src="https://github.com/MyMCIT/MyMCIT/assets/13663360/fd1d7974-26d9-409c-bfde-1dd0a00f16a0">

If you choose another account, you're still stuck in seas.upenn.edu land:
<img width="1109" alt="Screenshot 2024-03-17 at 9 34 19 PM" src="https://github.com/MyMCIT/MyMCIT/assets/13663360/750a67b3-e951-4ee0-a0c0-72218c9f5458">
