### PR TITLE
Semester and sentiment filters added to course reviews

### DIFF
--- a/src/pages/api/course-summaries.ts
+++ b/src/pages/api/course-summaries.ts
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import { supabase } from "../../lib/supabase";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/src/pages/courses/[course_code].tsx
+++ b/src/pages/courses/[course_code].tsx
@@ -13,6 +13,7 @@ import {
   OutlinedInput,
   Chip,
   MenuItem,
+  Button,
 } from "@mui/material";
 import { GetStaticPaths } from "next";
 import { supabase } from "@/lib/supabase";
@@ -233,6 +234,12 @@ export default function CourseReviews({
     setSelectedSentiments(typeof value === "string" ? value.split(",") : value);
   };
 
+  // clears out all the filters if user clicks on Reset button
+  const handleResetFilters = () => {
+    setSelectedSemesters([]);
+    setSelectedSentiments([]);
+  };
+
   // determine if any filters are applied by the user
   const isFilterApplied =
     selectedSemesters.length > 0 || selectedSentiments.length > 0;
@@ -399,6 +406,7 @@ export default function CourseReviews({
           padding: 2,
           display: "flex",
           gap: 2,
+          alignItems: "center",
         }}
       >
         <FormControl sx={{ m: 1, width: 300 }}>
@@ -449,6 +457,9 @@ export default function CourseReviews({
             ))}
           </Select>
         </FormControl>
+        <Button variant="outlined" onClick={handleResetFilters}>
+          Reset
+        </Button>
       </Box>
 
       {filteredReviews.map((review, index) => (

--- a/src/pages/courses/[course_code].tsx
+++ b/src/pages/courses/[course_code].tsx
@@ -181,10 +181,16 @@ export default function CourseReviews({
   // state to manage selected semester(s) filter
   const [selectedSemesters, setSelectedSemesters] = useState<string[]>([]);
 
+  // state to manage the reviews by positive/negative sentiment
+  const [selectedSentiments, setSelectedSentiments] = useState<string[]>([]);
+
   // array to hold all the semesters
   const allSemesters: string[] = [
     ...new Set(reviews.map((review) => review.semester)),
   ];
+
+  // sentiment options
+  const sentimentOptions = ["Positive", "Negative"];
 
   if (!reviews.length) {
     return (
@@ -202,11 +208,25 @@ export default function CourseReviews({
     setSelectedSemesters(typeof value === "string" ? value.split(",") : value);
   };
 
-  // filter displayed reviews based on selected semester(s) in the dropdown
+  // handles state changes for reviews sentiment
+  const handleSentimentChange = (event: { target: { value: any } }) => {
+    const {
+      target: { value },
+    } = event;
+    setSelectedSentiments(typeof value === "string" ? value.split(",") : value);
+  };
+
+  // filter displayed reviews based on selected filters(s) in the dropdowns
   const filteredReviews = reviews.filter(
     (review: Review) =>
-      selectedSemesters.length === 0 ||
-      selectedSemesters.includes(review.semester),
+      (selectedSemesters.length === 0 ||
+        selectedSemesters.includes(review.semester)) &&
+      (selectedSentiments.length === 0 ||
+        (selectedSentiments.includes("Positive") &&
+          (review.rating === "Liked" || review.rating === "Strongly Liked")) ||
+        (selectedSentiments.includes("Negative") &&
+          (review.rating === "Disliked" ||
+            review.rating === "Strongly Disliked"))),
   );
 
   const handleDelete = async (reviewId: number, courseCode: string) => {
@@ -283,7 +303,15 @@ export default function CourseReviews({
         </Grid>
       </Paper>
 
-      <Box sx={{ maxWidth: 800, margin: "auto" }}>
+      <Box
+        sx={{
+          maxWidth: 800,
+          margin: "auto",
+          padding: 2,
+          display: "flex",
+          gap: 2,
+        }}
+      >
         <FormControl sx={{ m: 1, width: 300 }}>
           <InputLabel id="semester-select-label">Semester</InputLabel>
           <Select
@@ -303,6 +331,31 @@ export default function CourseReviews({
             {allSemesters.map((semester) => (
               <MenuItem key={semester} value={semester}>
                 {semester}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ m: 1, width: 300 }}>
+          <InputLabel id="sentiment-select-label">Sentiment</InputLabel>
+          <Select
+            labelId="sentiment-select-label"
+            multiple
+            value={selectedSentiments}
+            onChange={handleSentimentChange}
+            input={
+              <OutlinedInput id="select-multiple-chip" label="Sentiment" />
+            }
+            renderValue={(selected) => (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                {selected.map((value) => (
+                  <Chip key={value} label={value} />
+                ))}
+              </Box>
+            )}
+          >
+            {sentimentOptions.map((sentiment) => (
+              <MenuItem key={sentiment} value={sentiment}>
+                {sentiment}
               </MenuItem>
             ))}
           </Select>

--- a/src/pages/courses/[course_code].tsx
+++ b/src/pages/courses/[course_code].tsx
@@ -88,6 +88,7 @@ export const getStaticProps = async (
     const resSummary = await axios(
       `${apiUrl}/api/course-summaries?course_code=${course_code}`,
     );
+
     const courseSummary: CourseReviewSummary[] = await resSummary.data;
 
     // fetch course reviews
@@ -263,7 +264,11 @@ export default function CourseReviews({
     window.location.reload();
   };
 
-  const summary = courseSummary[0];
+  // fetch the course summary for the current course
+  const summary =
+    courseSummary.find(
+      (summary) => summary.course_code === course.course_code,
+    ) || null;
 
   const sections = [
     { label: "Total Reviews", key: "totalReviews" },
@@ -282,26 +287,32 @@ export default function CourseReviews({
         Reviews for {course.course_code}: {course.course_name}
       </Typography>
 
-      <Paper sx={{ maxWidth: 800, margin: "30px auto", padding: 2 }}>
-        <Grid container spacing={2}>
-          {sections.map(({ label, key }) => (
-            <Grid item key={key} xs={6} sm={3}>
-              <Box textAlign="center">
-                <Typography variant="subtitle1" color="textSecondary">
-                  {label}
-                </Typography>
-                <Typography variant="h6">
-                  {typeof summary[key] === "number"
-                    ? (summary[key] as number) % 1 === 0
-                      ? summary[key]
-                      : (summary[key] as number).toFixed(2)
-                    : summary[key]}
-                </Typography>
-              </Box>
-            </Grid>
-          ))}
-        </Grid>
-      </Paper>
+      {summary ? (
+        <Paper sx={{ maxWidth: 800, margin: "30px auto", padding: 2 }}>
+          <Grid container spacing={2}>
+            {sections.map(({ label, key }) => (
+              <Grid item key={key} xs={6} sm={3}>
+                <Box textAlign="center">
+                  <Typography variant="subtitle1" color="textSecondary">
+                    {label}
+                  </Typography>
+                  <Typography variant="h6">
+                    {typeof summary[key] === "number"
+                      ? (summary[key] as number) % 1 === 0
+                        ? summary[key]
+                        : (summary[key] as number).toFixed(2)
+                      : "N/A"}
+                  </Typography>
+                </Box>
+              </Grid>
+            ))}
+          </Grid>
+        </Paper>
+      ) : (
+        <Typography variant="h6" align="center" mt={5}>
+          No summary data is available for this course.
+        </Typography>
+      )}
 
       <Box
         sx={{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "downlevelIteration": true,
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
Now users can filter course reviews by semester and sentiment (postive/negative). Users can select more than one semester for filtering:

<img width="877" alt="Screenshot 2024-03-24 at 6 02 51 PM" src="https://github.com/MyMCIT/MyMCIT/assets/13663360/d1d7e829-c1c4-48da-b452-353010965ff1">

<img width="362" alt="Screenshot 2024-03-24 at 6 03 02 PM" src="https://github.com/MyMCIT/MyMCIT/assets/13663360/caf186bd-e228-4ab1-9531-3c65f53c2778">

Positive = Liked & Strongly Liked reviews
Negative = Disliked & Strongly Disliked reviews

Note a change was made to `tsconfig.json` here to support `es2015`, since that allows for `Set` filtering, which is more powerful, since Set contains unique values, eliminating the risk of duplicates in options presented to the user. Also, the `downlevelIteration` flag has been set to `true` because this allows use of the spread `...` operator for iterables like `Set`. 
