### PR TITLE
If not logged in, clicking on Create Review in Speed Dial takes unauthenticated user to Login screen

### DIFF
--- a/src/components/SpeedDial.tsx
+++ b/src/components/SpeedDial.tsx
@@ -45,7 +45,7 @@ export default function SpeedDialTooltipOpen() {
           queryParams: {
             hd: "seas.upenn.edu",
           },
-          redirectTo: baseUrl,
+          redirectTo: `${baseUrl}/reviews/create-review`,
         },
       })
       .catch(console.error);


### PR DESCRIPTION
Per beta tester's comment:

> "This is not a bug per-se, but bug-ish.

>Before I logged in, I tried to add a Review and clicking on the ""+"" was futile. Perhaps there can be a message somewhere >like, ""please login in order to write a review""

So have unhidden Create Review icon in Speed Dial; it's always there. But if an unauthenticated user clicks on it, they get routed to the Google OAuth login page. If they're already logged in, they get routed to the create review page.